### PR TITLE
Simple set shaper changes

### DIFF
--- a/app/javascript/components/biomaterial_table.js
+++ b/app/javascript/components/biomaterial_table.js
@@ -6,7 +6,6 @@ export class BiomaterialTableRow extends Component {
 
   render() {
     const { biomaterial, onClick, removeable, onRemove, index, selected } = this.props;
-
     let removeableTd;
 
     if (removeable) {
@@ -21,11 +20,14 @@ export class BiomaterialTableRow extends Component {
 
     return (
       <tr className={trClass} style={style} onClick={(e) => onClick(biomaterial, index, e) }>
+        <td>{biomaterial.id}</td>
         <td>{biomaterial.scientific_name}</td>
         <td>{biomaterial.gender}</td>
         <td>{biomaterial.phenotype}</td>
         <td>{biomaterial.supplier_name}</td>
         <td>{biomaterial.donor_id}</td>
+        <td>{biomaterial.tissue_type}</td>
+        <td>{biomaterial.owner_id}</td>
         {removeableTd}
       </tr>
     )
@@ -42,7 +44,9 @@ BiomaterialTableRow.defaultProps = {
     gender: '',
     phenotype: '',
     supplier_name: '',
-    donor_id: ''
+    donor_id: '',
+    tissue_type: '',
+    owner_id: ''
   }
 }
 
@@ -59,13 +63,16 @@ export class BiomaterialTable extends Component {
       <table className={tableClass}>
         <thead>
           <tr>
+            <th>ID</th>
             <th>Scientific Name</th>
             <th>Gender</th>
             <th>Phenotype</th>
             <th>Supplier Name</th>
             <th>Donor ID</th>
+            <th>Tissue Type</th>
+            <th>Sample Guardian</th>
             {/* If the materials are removeable have a blank table header for the extra column */}
-            { rest['removeable'] && <th></th>}
+            { rest['removeable'] && <th>Remove?</th>}
           </tr>
         </thead>
           <tbody>

--- a/app/javascript/components/set_table.js
+++ b/app/javascript/components/set_table.js
@@ -3,13 +3,15 @@ import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import FontAwesome from './font_awesome';
 
-const SetTable = ({ sets, selectedSet, onSetClick, hideOwner, addLink, fetching }) => {
+const SetTable = ({ sets, selectedSet, onSetClick, hideOwner, addLink, fetching, showLocked }) => {
   if (sets.length == 0) {
     return <p className="text-center">No sets found.</p>
   }
 
   let rows = sets.map((set, index) => {
-    return <SetRow set={set} selected={(set.id == selectedSet)} onClick={onSetClick} key={index} hideOwner={hideOwner} addLink={addLink} />;
+    if (!set.attributes.locked || (showLocked && set.attributes.locked)) {
+      return <SetRow set={set} selected={(set.id == selectedSet)} onClick={onSetClick} key={index} hideOwner={hideOwner} addLink={addLink} />;
+    }
   });
 
   // Show a spinning icon if more Sets are being fetched
@@ -43,7 +45,8 @@ const SetTable = ({ sets, selectedSet, onSetClick, hideOwner, addLink, fetching 
 SetTable.defaultProps = {
   sets: [],
   selectedSet: undefined,
-  addLink: false
+  addLink: false,
+  showLocked: true
 }
 
 export default SetTable;

--- a/app/javascript/layouts/set_shaper.js
+++ b/app/javascript/layouts/set_shaper.js
@@ -98,13 +98,20 @@ class SetShaper extends React.Component {
           <UserMessage></UserMessage>
           <div className="row">
           <div className="col-md-12">
-            <p>Find the set you wish to edit using the "My Created Sets" box. The materials in your selected
-              set will be listed in the box to the right. Alternatively, you can create a new empty set using the text box.<br />
-              A locked set (marked by <FontAwesome icon="lock" style={{"color": "#e61c1c"}} />)
-              cannot be changed in any way, and exists to provide a record of work.<br />Materials that are <span className="text-muted">greyed out</span> are unavailable, either because they are
-              part of an active work order, or because they have not yet been received by Sample Management. However, this has no impact on your ability to manipulate those materials within sets.<br />
-              Use <FontAwesome icon="times" /> to remove materials from a set.<br />
-              When browsing materials within a set, use the "First", "Previous", "Next" and "Last" buttons to move through pages of 25 materials.</p>
+            <p>Find the set you wish to edit using the "My Created Sets" box.
+            The materials in your selected set will be listed in the box to the
+            right. Alternatively, you can create a new empty set using the text
+            box.<br />A locked set (marked by
+            <FontAwesome icon="lock" style={{"color": "#e61c1c"}} />)
+            cannot be changed in any way, and exists to provide a record of
+            work.<br />Materials that are <span className="text-muted">greyed
+            out</span> are unavailable, either because they are part of an
+            active work order, or because they have not yet been received by
+            Sample Management. However, this has no impact on your ability to
+            manipulate those materials within sets.<br />Use
+            <FontAwesome icon="times" /> to remove materials from a set.<br />
+            When browsing materials within a set, use the "First", "Previous",
+            "Next" and "Last" buttons to move through pages of 25 materials.</p>
           </div>
             <div className="col-md-3">
               <Panel>
@@ -137,7 +144,7 @@ class SetShaper extends React.Component {
 
           <div className="row">
             <div className="col-md-12">
-              <p>Here you can find materials that you wish to add to the set you have selected above. You can look through your own sets - including those which are locked - or all of the sets within Aker (using the "All Sets" tab).<br />Once you've found the materials you're interested in, drag them into your chosen set in the top window to add the material to that set. Use the 'CMD' or 'CTRL' key to select multiple materials.<br /><strong>Sets cannot be changed</strong> in the below section, so any materials you drag into an above set will also remain in their original set.</p>
+              <p>Here you can find materials that you wish to add to the set you have selected above. You can look through your own sets - including those which are locked - or all of the sets within Aker (using the "All Sets" tab).<br />Once you've found the materials you're interested in, drag them into your chosen set in the top window to add the material to that set. Use 'CMD' or 'CTRL' and click to select multiple materials, or select one material, then 'SHIFT' and click another to select all materials between (inclusive).<br /><strong>Sets cannot be changed</strong> in the below section, so any materials you drag into an above set will also remain in their original set.</p>
             </div>
             <div className="col-md-3">
               <Panel>

--- a/app/javascript/layouts/set_shaper.js
+++ b/app/javascript/layouts/set_shaper.js
@@ -94,50 +94,31 @@ class SetShaper extends React.Component {
     return (
       <Router basename={ basename }>
         <div className="container-fluid">
-
-          <div className="row">
-            <div className="col-md-12">
-              <h1>Set Browser</h1>
-            </div>
-          </div>
-
+          <h1>Simple Sets Interface</h1>
           <UserMessage></UserMessage>
-
           <div className="row">
+          <div className="col-md-12">
+            <p>Find the set you wish to edit using the "My Created Sets" box. The materials in your selected
+              set will be listed in the box to the right. Alternatively, you can create a new empty set using the text box.<br />
+              A locked set (marked by <FontAwesome icon="lock" style={{"color": "#e61c1c"}} />)
+              cannot be changed in any way, and exists to provide a record of work.<br />Materials that are <span className="text-muted">greyed out</span> are unavailable, either because they are
+              part of an active work order, or because they have not yet been received by Sample Management. However, this has no impact on your ability to manipulate those materials within sets.<br />
+              Use <FontAwesome icon="times" /> to remove materials from a set.<br />
+              When browsing materials within a set, use the "First", "Previous", "Next" and "Last" buttons to move through pages of 25 materials.</p>
+          </div>
             <div className="col-md-3">
               <Panel>
-                <Heading title="Target set" />
+                <Heading title="My Created Sets" />
 
                 <Body onScroll={debounce((e) => this.onScroll(e, 'top'), true)} style={{height: '280px', overflowY: 'scroll'}}>
-                  <ul className="nav nav-tabs" role="tablist">
-                    <li role="presentation" className="active">
-                      <a onClick={ (e) => this.setTabNumber('top', 0) } href="#mySets" aria-controls="mySets" role="tab" data-toggle="tab">My Sets</a>
-                    </li>
-                    <li role="presentation">
-                      <a onClick={ (e) => this.setTabNumber('top', 1) } href="#allSets" aria-controls="allSets" role="tab" data-toggle="tab">All Sets</a>
-                    </li>
-                  </ul>
-
-                  <div className="tab-content">
-                    <div role="tabpanel" className="tab-pane active" id="mySets">
-                      <SelectableSetTable
-                        sets={ userSets }
-                        selectionType="top"
-                        hideOwner={ true }
-                        addLink={ true }
-                        fetching={ this.state.fetching }
-                      />
-                    </div>
-                    <div role="tabpanel" className="tab-pane" id="allSets">
-                      <SelectableSetTable
-                        sets={ sets }
-                        selectionType="top"
-                        addLink={ true }
-                        fetching={ this.state.fetching }
-                      />
-                    </div>
-                  </div>
-
+                  <SelectableSetTable
+                    sets={ userSets }
+                    selectionType="top"
+                    hideOwner={ true }
+                    addLink={ true }
+                    showLocked={ false }
+                    fetching={ this.state.fetching }
+                  />
                 </Body>
 
                 <Footer>
@@ -155,10 +136,12 @@ class SetShaper extends React.Component {
           </div>
 
           <div className="row">
+            <div className="col-md-12">
+              <p>Here you can find materials that you wish to add to the set you have selected above. You can look through your own sets - including those which are locked - or all of the sets within Aker (using the "All Sets" tab).<br />Once you've found the materials you're interested in, drag them into your chosen set in the top window to add the material to that set. Use the 'CMD' or 'CTRL' key to select multiple materials.<br /><strong>Sets cannot be changed</strong> in the below section, so any materials you drag into an above set will also remain in their original set.</p>
+            </div>
             <div className="col-md-3">
-
               <Panel>
-                <Heading title="Source set" />
+                <Heading title="Set Browser" />
                 <Body onScroll={debounce((e) => this.onScroll(e, 'bottom'), true)} style={{height: '320px', overflowY: 'scroll'}}>
                   <ul className="nav nav-tabs" role="tablist">
                     <li role="presentation" className="active">


### PR DESCRIPTION
- Added instructions
- Only show user-owned, unlocked sets in the top section to re-inforce
the idea that the top section is for "doing", while the bottom is for
viewing.
- Add more metadata columns to the materials view

## Current
![screen shot 2018-06-13 at 16 22 39](https://user-images.githubusercontent.com/18176485/41361062-06696f6a-6f26-11e8-82c0-dde02a712216.png)

## Proposed
![screen shot 2018-06-13 at 16 23 33](https://user-images.githubusercontent.com/18176485/41361113-25400390-6f26-11e8-9326-4bad9d6cd101.png)
